### PR TITLE
Add Google Chat notification scripts for CI/CD workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,6 +33,7 @@ jobs:
         run: mkdocs build
 
       - name: Deploy to gh-pages branch
+        id: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +56,9 @@ jobs:
             echo "❌ Failed to decode the webhook URL."
             exit 0
           fi
-
-          curl -s -X POST -H "Content-Type: application/json" \
-            -d "{\"text\": \"📘 **Documentation Update**\n\nZSoftly documentation has been deployed to GitHub Pages.\n\n**Repo**: ${{ github.repository }}\n**URL**: https://zsoftly.github.io/zsoftly-services/\n**Run**: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            "$WEBHOOK_URL"
+          
+          # Make sure the script is executable
+          chmod +x ./scripts/send-notification.sh
+          
+          # Send the notification using the script
+          ./scripts/send-notification.sh "$WEBHOOK_URL" "${{ github.repository }}" "${{ github.run_id }}"

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -55,7 +55,7 @@ jobs:
           fi
           echo "::set-output name=result::true"
 
-  validate:
+  validate-and-notify:
     needs: setup
     runs-on: ubuntu-latest
     steps:
@@ -73,18 +73,12 @@ jobs:
           pip install mkdocs-material
           
       - name: Check for broken links
+        id: validation
         run: |
           echo "Checking for broken internal links and image references..."
           mkdocs build --strict
           echo "✅ Documentation validation passed"
-  
-  comment-pr:
-    needs: validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
+          
       # Only add PR comment if this is a pull request  
       - name: Comment on PR
         if: github.event_name == 'pull_request'
@@ -105,6 +99,8 @@ jobs:
             \`\`\`bash
             mkdocs serve
             \`\`\`
+            
+            **This PR is ready for review and can be merged.**
             `;
             
             github.rest.issues.createComment({

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - 'feat*'    # Matches feat, feat/, feat-anything
+      - 'feature/*' # Matches feature/anything
       - 'issue*'   # Matches issue, issue/, issue-anything
     branches-ignore:
       - main
       - gh-pages
   pull_request:
     branches: 
-      - main      # Only run on PRs targeting main branch
+      - 'main'     # Only run on PRs targeting main branch
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -2,12 +2,15 @@ name: Validate Documentation
 
 on:
   push:
+    branches:
+      - 'feat*'    # Matches feat, feat/, feat-anything
+      - 'issue*'   # Matches issue, issue/, issue-anything
     branches-ignore:
       - main
       - gh-pages
   pull_request:
     branches: 
-      - '*'
+      - main      # Only run on PRs targeting main branch
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -89,7 +92,7 @@ jobs:
               body: output
             })
       
-      # Send notification
+      # Send notification using the external script
       - name: Send notification
         env:
           ENCODED_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
@@ -106,72 +109,23 @@ jobs:
             exit 0
           fi
           
-          # Create thread key based on PR or branch
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            THREAD_KEY="${{ github.repository }}-pr-${{ github.event.pull_request.number }}"
-            MESSAGE="✅ <b>Documentation Validation Passed</b><br>PR #${{ github.event.pull_request.number }} is ready for review and can be merged."
-            PR_LINK="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-            
-            JSON_PAYLOAD="{
-              \"text\": \"$MESSAGE\",
-              \"thread\": {
-                \"threadKey\": \"$THREAD_KEY\"
-              },
-              \"cards\": [{
-                \"sections\": [{
-                  \"widgets\": [{
-                    \"buttons\": [{
-                      \"textButton\": {
-                        \"text\": \"Review PR\",
-                        \"onClick\": {
-                          \"openLink\": {
-                            \"url\": \"$PR_LINK\"
-                          }
-                        }
-                      }
-                    },
-                    {
-                      \"textButton\": {
-                        \"text\": \"View Workflow\",
-                        \"onClick\": {
-                          \"openLink\": {
-                            \"url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
-                          }
-                        }
-                      }
-                    }]
-                  }]
-                }]
-              }]
-            }"
-          else
-            THREAD_KEY="${{ github.repository }}-branch-${GITHUB_REF##*/}"
-            MESSAGE="✅ <b>Documentation Validation Passed</b><br>Branch '${GITHUB_REF##*/}' validation completed successfully."
-            
-            JSON_PAYLOAD="{
-              \"text\": \"$MESSAGE\",
-              \"thread\": {
-                \"threadKey\": \"$THREAD_KEY\"
-              },
-              \"cards\": [{
-                \"sections\": [{
-                  \"widgets\": [{
-                    \"buttons\": [{
-                      \"textButton\": {
-                        \"text\": \"View Workflow\",
-                        \"onClick\": {
-                          \"openLink\": {
-                            \"url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
-                          }
-                        }
-                      }
-                    }]
-                  }]
-                }]
-              }]
-            }"
-          fi
+          # Make sure the script is executable
+          chmod +x ./scripts/send-validation-notification.sh
           
-          curl -s -X POST -H "Content-Type: application/json" \
-            -d "$JSON_PAYLOAD" \
-            "$WEBHOOK_URL"
+          # For PR events, include PR information
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            ./scripts/send-validation-notification.sh \
+              "$WEBHOOK_URL" \
+              "${{ github.repository }}" \
+              "${{ github.run_id }}" \
+              "${{ github.event.pull_request.number }}"
+          else
+            # For push events, include branch name
+            BRANCH_NAME="${GITHUB_REF##*/}"
+            ./scripts/send-validation-notification.sh \
+              "$WEBHOOK_URL" \
+              "${{ github.repository }}" \
+              "${{ github.run_id }}" \
+              "" \
+              "$BRANCH_NAME"
+          fi

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -80,10 +80,14 @@ jobs:
   
   comment-pr:
     needs: validate
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Only add PR comment if this is a pull request  
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -109,3 +113,40 @@ jobs:
               repo: context.repo.repo,
               body: output
             })
+      
+      # Send notification using the external script  
+      - name: Send Google Chat notification
+        env:
+          ENCODED_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+        run: |
+          if [ -z "$ENCODED_WEBHOOK_URL" ]; then
+            echo "❌ GOOGLE_CHAT_WEBHOOK_URL secret is not set. Skipping notification."
+            exit 0
+          fi
+
+          WEBHOOK_URL=$(echo "$ENCODED_WEBHOOK_URL" | base64 -d)
+
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "❌ Failed to decode the webhook URL."
+            exit 0
+          fi
+          
+          # Make sure the script is executable
+          chmod +x ./scripts/send-validation-notification.sh
+          
+          # For PR events, include PR information
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            ./scripts/send-validation-notification.sh \
+              "$WEBHOOK_URL" \
+              "${{ github.repository }}" \
+              "${{ github.run_id }}" \
+              "${{ github.event.pull_request.number }}" \
+              "${{ github.event.pull_request.title }}" \
+              "${{ github.event.pull_request.user.login }}"
+          else
+            # For push events, don't include PR info
+            ./scripts/send-validation-notification.sh \
+              "$WEBHOOK_URL" \
+              "${{ github.repository }}" \
+              "${{ github.run_id }}"
+          fi

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -3,15 +3,13 @@ name: Validate Documentation
 on:
   push:
     branches:
-      - 'feat*'    # Matches feat, feat/, feat-anything
-      - 'feature/*' # Matches feature/anything
-      - 'issue*'   # Matches issue, issue/, issue-anything
-    branches-ignore:
-      - main
-      - gh-pages
+      - 'feat*'     # Matches feat, feat/, feat-anything
+      - 'issue*'    # Matches issue, issue/, issue-anything
+      - '!main'     # Excludes main branch
+      - '!gh-pages' # Excludes gh-pages branch
   pull_request:
     branches: 
-      - 'main'     # Only run on PRs targeting main branch
+      - 'main'      # Only run on PRs targeting main branch
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -3,11 +3,11 @@ name: Validate Documentation
 on:
   push:
     branches-ignore:
-      - main  # Main branch is already covered by the deployment workflow
-      - gh-pages  # Skip the generated pages branch
+      - main
+      - gh-pages
   pull_request:
     branches: 
-      - '*'  # Run on all pull requests
+      - '*'
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -15,17 +15,14 @@ permissions:
   issues: write
   pull-requests: write
 
-# Simple concurrency configuration: one run per branch or PR
+# Simple concurrency - one run per branch or PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  validate-and-notify:
+  validate:
     runs-on: ubuntu-latest
-    # Skip push events that are associated with a PR
-    # This avoids duplicate runs when pushing to a PR branch
-    if: ${{ github.event_name == 'pull_request' || !contains(github.event.head_commit.message, 'Merge pull request') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -38,7 +35,7 @@ jobs:
       - name: Setup documentation files
         run: |
           mkdir -p docs/stylesheets
-          # Only copy files if they don't exist in docs/ already
+          # Copy files if needed
           if [ ! -f docs/index.md ]; then
             cp README.md docs/index.md
           fi
@@ -47,7 +44,7 @@ jobs:
               cp $file docs/
             fi
           done
-          # Remove the filepath comments and fix navigation
+          # Fix file content
           for file in docs/*.md; do
             if [ -f "$file" ] && [ "$(head -n 1 $file | grep 'filepath:')" ]; then
               sed -i '1d' "$file"
@@ -56,7 +53,6 @@ jobs:
               sed -i 's|\[Back to Service Portfolio\](README.md)|[Back to Home](index.md)|g' "$file"
             fi
           done
-          # Remove index.md entries that aren't needed
           if [ -f "docs/README.md" ]; then
             rm -f docs/README.md
           fi
@@ -66,14 +62,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install mkdocs-material
           
-      - name: Check for broken links
-        id: validation
+      - name: Run validation
         run: |
-          echo "Checking for broken internal links and image references..."
+          echo "Running documentation validation..."
           mkdocs build --strict
           echo "✅ Documentation validation passed"
           
-      # Only add PR comment if this is a pull request  
+      # Add PR comment
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
@@ -83,16 +78,6 @@ jobs:
             const output = `## Documentation Validation Results
             
             ✅ Documentation validation completed successfully!
-            
-            The following checks passed:
-            - MkDocs build with strict mode
-            - Internal link validation
-            - Image reference validation
-            
-            You can preview these changes locally by running:
-            \`\`\`bash
-            mkdocs serve
-            \`\`\`
             
             **This PR is ready for review and can be merged.**
             `;
@@ -104,8 +89,8 @@ jobs:
               body: output
             })
       
-      # Send notification using the external script  
-      - name: Send Google Chat notification
+      # Send notification
+      - name: Send notification
         env:
           ENCODED_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
         run: |
@@ -121,22 +106,72 @@ jobs:
             exit 0
           fi
           
-          # Make sure the script is executable
-          chmod +x ./scripts/send-validation-notification.sh
-          
-          # For PR events, include PR information
+          # Create thread key based on PR or branch
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            ./scripts/send-validation-notification.sh \
-              "$WEBHOOK_URL" \
-              "${{ github.repository }}" \
-              "${{ github.run_id }}" \
-              "${{ github.event.pull_request.number }}" \
-              "${{ github.event.pull_request.title }}" \
-              "${{ github.event.pull_request.user.login }}"
+            THREAD_KEY="${{ github.repository }}-pr-${{ github.event.pull_request.number }}"
+            MESSAGE="✅ <b>Documentation Validation Passed</b><br>PR #${{ github.event.pull_request.number }} is ready for review and can be merged."
+            PR_LINK="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+            
+            JSON_PAYLOAD="{
+              \"text\": \"$MESSAGE\",
+              \"thread\": {
+                \"threadKey\": \"$THREAD_KEY\"
+              },
+              \"cards\": [{
+                \"sections\": [{
+                  \"widgets\": [{
+                    \"buttons\": [{
+                      \"textButton\": {
+                        \"text\": \"Review PR\",
+                        \"onClick\": {
+                          \"openLink\": {
+                            \"url\": \"$PR_LINK\"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      \"textButton\": {
+                        \"text\": \"View Workflow\",
+                        \"onClick\": {
+                          \"openLink\": {
+                            \"url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+                          }
+                        }
+                      }
+                    }]
+                  }]
+                }]
+              }]
+            }"
           else
-            # For push events, don't include PR info
-            ./scripts/send-validation-notification.sh \
-              "$WEBHOOK_URL" \
-              "${{ github.repository }}" \
-              "${{ github.run_id }}"
+            THREAD_KEY="${{ github.repository }}-branch-${GITHUB_REF##*/}"
+            MESSAGE="✅ <b>Documentation Validation Passed</b><br>Branch '${GITHUB_REF##*/}' validation completed successfully."
+            
+            JSON_PAYLOAD="{
+              \"text\": \"$MESSAGE\",
+              \"thread\": {
+                \"threadKey\": \"$THREAD_KEY\"
+              },
+              \"cards\": [{
+                \"sections\": [{
+                  \"widgets\": [{
+                    \"buttons\": [{
+                      \"textButton\": {
+                        \"text\": \"View Workflow\",
+                        \"onClick\": {
+                          \"openLink\": {
+                            \"url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
+                          }
+                        }
+                      }
+                    }]
+                  }]
+                }]
+              }]
+            }"
           fi
+          
+          curl -s -X POST -H "Content-Type: application/json" \
+            -d "$JSON_PAYLOAD" \
+            "$WEBHOOK_URL"

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -14,9 +14,10 @@ permissions:
   issues: write
   pull-requests: write
 
-# Prevent duplicate workflow runs when a PR is open for a branch
+# Concurrency configuration that properly handles both PR and push events
 concurrency:
-  group: validation-${{ github.head_ref || github.ref_name }}
+  # Use different group keys for PR and push events
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref_name) }}
   cancel-in-progress: true
 
 jobs:
@@ -50,12 +51,12 @@ jobs:
               console.log(`Skipping validation for push event as PR #${prs.data[0].number} exists`);
             }
             
-            return core.setOutput('has_pr', hasPR.toString());
+            core.setOutput('has_pr', hasPR.toString());
 
   setup:
     needs: [check-if-pr-exists]
     # Skip if this is a push event and there's an open PR for this branch
-    if: github.event_name == 'pull_request' || needs.check-if-pr-exists.outputs.has_pr != 'true'
+    if: ${{ github.event_name == 'pull_request' || needs.check-if-pr-exists.outputs.has_pr != 'true' }}
     runs-on: ubuntu-latest
     outputs:
       docs_ready: ${{ steps.setup_docs.outputs.result }}
@@ -94,7 +95,7 @@ jobs:
           if [ -f "docs/README.md" ]; then
             rm -f docs/README.md
           fi
-          echo "::set-output name=result::true"
+          echo "result=true" >> $GITHUB_OUTPUT
 
   validate-and-notify:
     needs: setup

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - main  # Main branch is already covered by the deployment workflow
+      - gh-pages  # Skip the generated pages branch
   pull_request:
     branches: 
       - '*'  # Run on all pull requests
@@ -13,8 +14,48 @@ permissions:
   issues: write
   pull-requests: write
 
+# Prevent duplicate workflow runs when a PR is open for a branch
+concurrency:
+  group: validation-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
+  # Skip validation on push events if there's an open PR for this branch
+  check-if-pr-exists:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      has_pr: ${{ steps.check_pr.outputs.has_pr }}
+    steps:
+      - name: Check for open PRs for this branch
+        id: check_pr
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            console.log(`Checking for open PRs for branch: ${branch}`);
+            
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${branch}`
+            });
+            
+            const hasPR = prs.data.length > 0;
+            console.log(`Branch has open PR: ${hasPR}`);
+            
+            if (hasPR) {
+              console.log(`Skipping validation for push event as PR #${prs.data[0].number} exists`);
+            }
+            
+            return core.setOutput('has_pr', hasPR.toString());
+
   setup:
+    needs: [check-if-pr-exists]
+    # Skip if this is a push event and there's an open PR for this branch
+    if: github.event_name == 'pull_request' || needs.check-if-pr-exists.outputs.has_pr != 'true'
     runs-on: ubuntu-latest
     outputs:
       docs_ready: ${{ steps.setup_docs.outputs.result }}

--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -8,58 +8,24 @@ on:
   pull_request:
     branches: 
       - '*'  # Run on all pull requests
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
   issues: write
   pull-requests: write
 
-# Concurrency configuration that properly handles both PR and push events
+# Simple concurrency configuration: one run per branch or PR
 concurrency:
-  # Use different group keys for PR and push events
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref_name) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Skip validation on push events if there's an open PR for this branch
-  check-if-pr-exists:
-    if: github.event_name == 'push'
+  validate-and-notify:
     runs-on: ubuntu-latest
-    outputs:
-      has_pr: ${{ steps.check_pr.outputs.has_pr }}
-    steps:
-      - name: Check for open PRs for this branch
-        id: check_pr
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const branch = context.ref.replace('refs/heads/', '');
-            console.log(`Checking for open PRs for branch: ${branch}`);
-            
-            const prs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              head: `${context.repo.owner}:${branch}`
-            });
-            
-            const hasPR = prs.data.length > 0;
-            console.log(`Branch has open PR: ${hasPR}`);
-            
-            if (hasPR) {
-              console.log(`Skipping validation for push event as PR #${prs.data[0].number} exists`);
-            }
-            
-            core.setOutput('has_pr', hasPR.toString());
-
-  setup:
-    needs: [check-if-pr-exists]
-    # Skip if this is a push event and there's an open PR for this branch
-    if: ${{ github.event_name == 'pull_request' || needs.check-if-pr-exists.outputs.has_pr != 'true' }}
-    runs-on: ubuntu-latest
-    outputs:
-      docs_ready: ${{ steps.setup_docs.outputs.result }}
+    # Skip push events that are associated with a PR
+    # This avoids duplicate runs when pushing to a PR branch
+    if: ${{ github.event_name == 'pull_request' || !contains(github.event.head_commit.message, 'Merge pull request') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -70,7 +36,6 @@ jobs:
           python-version: '3.x'
           
       - name: Setup documentation files
-        id: setup_docs
         run: |
           mkdir -p docs/stylesheets
           # Only copy files if they don't exist in docs/ already
@@ -95,19 +60,6 @@ jobs:
           if [ -f "docs/README.md" ]; then
             rm -f docs/README.md
           fi
-          echo "result=true" >> $GITHUB_OUTPUT
-
-  validate-and-notify:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
           
       - name: Install dependencies
         run: |

--- a/scripts/send-notification.sh
+++ b/scripts/send-notification.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Script to send rich notifications about documentation deployments to Google Chat
+# Usage: ./scripts/send-notification.sh <webhook_url> <repo> <run_id>
+
+# Exit on any error
+set -e
+
+WEBHOOK_URL="$1"
+REPO="$2"
+RUN_ID="$3"
+
+if [ -z "$WEBHOOK_URL" ]; then
+  echo "❌ Error: Webhook URL is required"
+  exit 1
+fi
+
+if [ -z "$REPO" ]; then
+  echo "❌ Error: Repository name is required"
+  exit 1
+fi
+
+if [ -z "$RUN_ID" ]; then
+  echo "❌ Error: Run ID is required"
+  exit 1
+fi
+
+# Extract organization and repository name
+IFS='/' read -r ORG REPO_NAME <<< "$REPO"
+
+# Setup URLs
+ACTIONS_URL="https://github.com/${REPO}/actions"
+GH_PAGES_URL="https://${ORG}.github.io/${REPO_NAME}/"
+CURRENT_RUN_URL="${ACTIONS_URL}/runs/${RUN_ID}"
+PAGES_WORKFLOW_URL="${ACTIONS_URL}/workflows/pages/pages-build-deployment"
+
+# Get the logo URL - using color logo with no background
+LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/217183861/Logo%20Files/png/Color%20logo%20-%20no%20background.png"
+
+# Create Google Chat card format JSON
+JSON_PAYLOAD=$(cat <<EOF
+{
+  "cardsV2": [{
+    "card": {
+      "header": {
+        "title": "🚀 Documentation Deployment Process",
+        "subtitle": "${REPO}",
+        "imageUrl": "${LOGO_URL}",
+        "imageStyle": "AVATAR"
+      },
+      "sections": [
+        {
+          "header": "Step 1: Documentation Build & Push ✅",
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "The documentation has been built and pushed to the gh-pages branch."
+              }
+            },
+            {
+              "buttonList": {
+                "buttons": [
+                  {
+                    "text": "View Build Details",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${CURRENT_RUN_URL}"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "header": "Step 2: GitHub Pages Deployment ⏳",
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "The GitHub Pages workflow has been triggered and will deploy shortly."
+              }
+            },
+            {
+              "buttonList": {
+                "buttons": [
+                  {
+                    "text": "Check Pages Workflow",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${PAGES_WORKFLOW_URL}"
+                      }
+                    }
+                  },
+                  {
+                    "text": "View Documentation",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${GH_PAGES_URL}"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "widgets": [
+            {
+              "decoratedText": {
+                "text": "Please verify the GitHub Pages deployment completed successfully",
+                "startIcon": {
+                  "knownIcon": "DESCRIPTION"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }]
+}
+EOF
+)
+
+# Send the notification to Google Chat
+curl -s -X POST -H "Content-Type: application/json" \
+  -d "$JSON_PAYLOAD" \
+  "$WEBHOOK_URL"
+
+echo "✅ Notification sent successfully"

--- a/scripts/send-notification.sh
+++ b/scripts/send-notification.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Script to send rich notifications about documentation deployments to Google Chat
-# Usage: ./scripts/send-notification.sh <webhook_url> <repo> <run_id>
+# Script to send notifications about documentation validation to Google Chat
+# Usage: ./scripts/send-validation-notification.sh <webhook_url> <repo> <run_id> <pr_number> <pr_title> <pr_author>
 
 # Exit on any error
 set -e
@@ -9,6 +9,9 @@ set -e
 WEBHOOK_URL="$1"
 REPO="$2"
 RUN_ID="$3"
+PR_NUMBER="$4"
+PR_TITLE="$5"
+PR_AUTHOR="$6"
 
 if [ -z "$WEBHOOK_URL" ]; then
   echo "❌ Error: Webhook URL is required"
@@ -25,101 +28,43 @@ if [ -z "$RUN_ID" ]; then
   exit 1
 fi
 
-# Extract organization and repository name
-IFS='/' read -r ORG REPO_NAME <<< "$REPO"
-
-# Setup URLs
-ACTIONS_URL="https://github.com/${REPO}/actions"
-GH_PAGES_URL="https://${ORG}.github.io/${REPO_NAME}/"
-CURRENT_RUN_URL="${ACTIONS_URL}/runs/${RUN_ID}"
-PAGES_WORKFLOW_URL="${ACTIONS_URL}/workflows/pages/pages-build-deployment"
-
 # Get the logo URL - using color logo with no background
 LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/217183861/Logo%20Files/png/Color%20logo%20-%20no%20background.png"
 
-# Create Google Chat card format JSON
-JSON_PAYLOAD=$(cat <<EOF
+# Create Google Chat card format JSON for validation results
+if [ -z "$PR_NUMBER" ]; then
+  # For branch push validations
+  JSON_PAYLOAD=$(cat <<EOF
 {
   "cards": [
     {
       "header": {
-        "title": "🚀 Documentation Deployment Process",
+        "title": "📋 Documentation Validation",
         "subtitle": "${REPO}",
         "imageUrl": "${LOGO_URL}"
       },
       "sections": [
         {
-          "header": "Step 1: Documentation Build & Push ✅",
+          "header": "✅ Validation Successful",
           "widgets": [
             {
               "textParagraph": {
-                "text": "The documentation has been built and pushed to the gh-pages branch."
+                "text": "Documentation validation has successfully completed for branch push."
               }
-            }
-          ]
-        },
-        {
-          "widgets": [
+            },
             {
               "buttons": [
                 {
                   "textButton": {
-                    "text": "View Build Details",
+                    "text": "View Workflow Run",
                     "onClick": {
                       "openLink": {
-                        "url": "${CURRENT_RUN_URL}"
+                        "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
                       }
                     }
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "header": "Step 2: GitHub Pages Deployment ⏳",
-          "widgets": [
-            {
-              "textParagraph": {
-                "text": "The GitHub Pages workflow has been triggered and will deploy shortly."
-              }
-            }
-          ]
-        },
-        {
-          "widgets": [
-            {
-              "buttons": [
-                {
-                  "textButton": {
-                    "text": "Check Pages Workflow",
-                    "onClick": {
-                      "openLink": {
-                        "url": "${PAGES_WORKFLOW_URL}"
-                      }
-                    }
-                  }
-                },
-                {
-                  "textButton": {
-                    "text": "View Documentation",
-                    "onClick": {
-                      "openLink": {
-                        "url": "${GH_PAGES_URL}"
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "widgets": [
-            {
-              "textParagraph": {
-                "text": "⚠️ Please verify the GitHub Pages deployment completed successfully"
-              }
             }
           ]
         }
@@ -129,10 +74,73 @@ JSON_PAYLOAD=$(cat <<EOF
 }
 EOF
 )
+else
+  # For PR validations
+  JSON_PAYLOAD=$(cat <<EOF
+{
+  "cards": [
+    {
+      "header": {
+        "title": "📋 Documentation Validation",
+        "subtitle": "${REPO}",
+        "imageUrl": "${LOGO_URL}"
+      },
+      "sections": [
+        {
+          "header": "✅ Validation Successful",
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "Documentation validation has successfully completed for PR #${PR_NUMBER}."
+              }
+            },
+            {
+              "textParagraph": {
+                "text": "<b>Pull Request:</b> ${PR_INFO:-#${PR_NUMBER}: ${PR_TITLE}}"
+              }
+            },
+            {
+              "textParagraph": {
+                "text": "<b>Author:</b> ${PR_AUTHOR}"
+              }
+            },
+            {
+              "buttons": [
+                {
+                  "textButton": {
+                    "text": "View Pull Request",
+                    "onClick": {
+                      "openLink": {
+                        "url": "https://github.com/${REPO}/pull/${PR_NUMBER}"
+                      }
+                    }
+                  }
+                },
+                {
+                  "textButton": {
+                    "text": "View Workflow Run",
+                    "onClick": {
+                      "openLink": {
+                        "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+)
+fi
 
 # Send the notification to Google Chat
 curl -s -X POST -H "Content-Type: application/json" \
   -d "$JSON_PAYLOAD" \
   "$WEBHOOK_URL"
 
-echo "✅ Notification sent successfully"
+echo "✅ Validation notification sent successfully"

--- a/scripts/send-notification.sh
+++ b/scripts/send-notification.sh
@@ -40,13 +40,12 @@ LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/2171
 # Create Google Chat card format JSON
 JSON_PAYLOAD=$(cat <<EOF
 {
-  "cardsV2": [{
-    "card": {
+  "cards": [
+    {
       "header": {
         "title": "🚀 Documentation Deployment Process",
         "subtitle": "${REPO}",
-        "imageUrl": "${LOGO_URL}",
-        "imageStyle": "AVATAR"
+        "imageUrl": "${LOGO_URL}"
       },
       "sections": [
         {
@@ -56,11 +55,15 @@ JSON_PAYLOAD=$(cat <<EOF
               "textParagraph": {
                 "text": "The documentation has been built and pushed to the gh-pages branch."
               }
-            },
+            }
+          ]
+        },
+        {
+          "widgets": [
             {
-              "buttonList": {
-                "buttons": [
-                  {
+              "buttons": [
+                {
+                  "textButton": {
                     "text": "View Build Details",
                     "onClick": {
                       "openLink": {
@@ -68,8 +71,8 @@ JSON_PAYLOAD=$(cat <<EOF
                       }
                     }
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         },
@@ -80,19 +83,25 @@ JSON_PAYLOAD=$(cat <<EOF
               "textParagraph": {
                 "text": "The GitHub Pages workflow has been triggered and will deploy shortly."
               }
-            },
+            }
+          ]
+        },
+        {
+          "widgets": [
             {
-              "buttonList": {
-                "buttons": [
-                  {
+              "buttons": [
+                {
+                  "textButton": {
                     "text": "Check Pages Workflow",
                     "onClick": {
                       "openLink": {
                         "url": "${PAGES_WORKFLOW_URL}"
                       }
                     }
-                  },
-                  {
+                  }
+                },
+                {
+                  "textButton": {
                     "text": "View Documentation",
                     "onClick": {
                       "openLink": {
@@ -100,26 +109,23 @@ JSON_PAYLOAD=$(cat <<EOF
                       }
                     }
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         },
         {
           "widgets": [
             {
-              "decoratedText": {
-                "text": "Please verify the GitHub Pages deployment completed successfully",
-                "startIcon": {
-                  "knownIcon": "DESCRIPTION"
-                }
+              "textParagraph": {
+                "text": "⚠️ Please verify the GitHub Pages deployment completed successfully"
               }
             }
           ]
         }
       ]
     }
-  }]
+  ]
 }
 EOF
 )

--- a/scripts/send-validation-notification.sh
+++ b/scripts/send-validation-notification.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Script to send notifications about documentation validation to Google Chat
-# Usage: ./scripts/send-validation-notification.sh <webhook_url> <repo> <run_id> <pr_number> <pr_title> <pr_author>
+# Script to send rich notifications about documentation deployments to Google Chat
+# Usage: ./scripts/send-notification.sh <webhook_url> <repo> <run_id>
 
 # Exit on any error
 set -e
@@ -9,9 +9,6 @@ set -e
 WEBHOOK_URL="$1"
 REPO="$2"
 RUN_ID="$3"
-PR_NUMBER="$4"
-PR_TITLE="$5"
-PR_AUTHOR="$6"
 
 if [ -z "$WEBHOOK_URL" ]; then
   echo "❌ Error: Webhook URL is required"
@@ -28,77 +25,91 @@ if [ -z "$RUN_ID" ]; then
   exit 1
 fi
 
-# For non-PR runs, we may not have PR information
-if [ -z "$PR_NUMBER" ]; then
-  PR_INFO="Branch push validation"
-  BUTTONS_SECTION="\"buttons\": [
-      {
-        \"textButton\": {
-          \"text\": \"View Workflow Run\",
-          \"onClick\": {
-            \"openLink\": {
-              \"url\": \"https://github.com/${REPO}/actions/runs/${RUN_ID}\"
-            }
-          }
-        }
-      }
-    ]"
-else
-  PR_INFO="#${PR_NUMBER}: ${PR_TITLE}"
-  PR_AUTHOR_INFO="${PR_AUTHOR}"
-  
-  BUTTONS_SECTION="\"buttons\": [
-      {
-        \"textButton\": {
-          \"text\": \"View Pull Request\",
-          \"onClick\": {
-            \"openLink\": {
-              \"url\": \"https://github.com/${REPO}/pull/${PR_NUMBER}\"
-            }
-          }
-        }
-      },
-      {
-        \"textButton\": {
-          \"text\": \"View Workflow Run\",
-          \"onClick\": {
-            \"openLink\": {
-              \"url\": \"https://github.com/${REPO}/actions/runs/${RUN_ID}\"
-            }
-          }
-        }
-      }
-    ]"
-fi
+# Extract organization and repository name
+IFS='/' read -r ORG REPO_NAME <<< "$REPO"
+
+# Setup URLs
+ACTIONS_URL="https://github.com/${REPO}/actions"
+GH_PAGES_URL="https://${ORG}.github.io/${REPO_NAME}/"
+CURRENT_RUN_URL="${ACTIONS_URL}/runs/${RUN_ID}"
+PAGES_WORKFLOW_URL="${ACTIONS_URL}/workflows/pages/pages-build-deployment"
 
 # Get the logo URL - using color logo with no background
 LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/217183861/Logo%20Files/png/Color%20logo%20-%20no%20background.png"
 
-# Create Google Chat card format JSON for validation results
-if [ -z "$PR_NUMBER" ]; then
-  # For branch push validations
-  JSON_PAYLOAD=$(cat <<EOF
+# Create Google Chat card format JSON
+JSON_PAYLOAD=$(cat <<EOF
 {
   "cards": [
     {
       "header": {
-        "title": "📋 Documentation Validation",
+        "title": "🚀 Documentation Deployment Process",
         "subtitle": "${REPO}",
         "imageUrl": "${LOGO_URL}"
       },
       "sections": [
         {
-          "header": "✅ Validation Successful",
+          "header": "Step 1: Documentation Build & Push ✅",
           "widgets": [
             {
               "textParagraph": {
-                "text": "Documentation validation has successfully completed for branch push."
+                "text": "The documentation has been built and pushed to the gh-pages branch."
               }
+            },
+            {
+              "buttons": [
+                {
+                  "textButton": {
+                    "text": "View Build Details",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${CURRENT_RUN_URL}"
+                      }
+                    }
+                  }
+                }
+              ]
             }
           ]
         },
         {
-          ${BUTTONS_SECTION}
+          "header": "Step 2: GitHub Pages Deployment ⏳",
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "The GitHub Pages workflow has been triggered and will deploy shortly."
+              }
+            },
+            {
+              "buttons": [
+                {
+                  "textButton": {
+                    "text": "Check Pages Workflow",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${PAGES_WORKFLOW_URL}"
+                      }
+                    }
+                  }
+                },
+                {
+                  "textButton": {
+                    "text": "View Documentation",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${GH_PAGES_URL}"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "textParagraph": {
+                "text": "⚠️ Please verify the GitHub Pages deployment completed successfully"
+              }
+            }
+          ]
         }
       ]
     }
@@ -106,52 +117,10 @@ if [ -z "$PR_NUMBER" ]; then
 }
 EOF
 )
-else
-  # For PR validations
-  JSON_PAYLOAD=$(cat <<EOF
-{
-  "cards": [
-    {
-      "header": {
-        "title": "📋 Documentation Validation",
-        "subtitle": "${REPO}",
-        "imageUrl": "${LOGO_URL}"
-      },
-      "sections": [
-        {
-          "header": "✅ Validation Successful",
-          "widgets": [
-            {
-              "textParagraph": {
-                "text": "Documentation validation has successfully completed for PR #${PR_NUMBER}."
-              }
-            },
-            {
-              "textParagraph": {
-                "text": "<b>Pull Request:</b> ${PR_INFO}"
-              }
-            },
-            {
-              "textParagraph": {
-                "text": "<b>Author:</b> ${PR_AUTHOR_INFO}"
-              }
-            }
-          ]
-        },
-        {
-          ${BUTTONS_SECTION}
-        }
-      ]
-    }
-  ]
-}
-EOF
-)
-fi
 
 # Send the notification to Google Chat
 curl -s -X POST -H "Content-Type: application/json" \
   -d "$JSON_PAYLOAD" \
   "$WEBHOOK_URL"
 
-echo "✅ Validation notification sent successfully"
+echo "✅ Notification sent successfully"

--- a/scripts/send-validation-notification.sh
+++ b/scripts/send-validation-notification.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Script to send notifications about documentation validation to Google Chat
+# Usage: ./scripts/send-validation-notification.sh <webhook_url> <repo> <run_id> <pr_number> <pr_title> <pr_author>
+
+# Exit on any error
+set -e
+
+WEBHOOK_URL="$1"
+REPO="$2"
+RUN_ID="$3"
+PR_NUMBER="$4"
+PR_TITLE="$5"
+PR_AUTHOR="$6"
+
+if [ -z "$WEBHOOK_URL" ]; then
+  echo "❌ Error: Webhook URL is required"
+  exit 1
+fi
+
+if [ -z "$REPO" ]; then
+  echo "❌ Error: Repository name is required"
+  exit 1
+fi
+
+if [ -z "$RUN_ID" ]; then
+  echo "❌ Error: Run ID is required"
+  exit 1
+fi
+
+# For non-PR runs, we may not have PR information
+if [ -z "$PR_NUMBER" ]; then
+  PR_INFO="Branch push validation"
+  PR_BUTTONS=""
+else
+  PR_INFO="#${PR_NUMBER}: ${PR_TITLE}"
+  PR_AUTHOR_INFO="${PR_AUTHOR}"
+  
+  PR_BUTTONS=$(cat <<EOF
+  {
+    "buttonList": {
+      "buttons": [
+        {
+          "text": "View Pull Request",
+          "onClick": {
+            "openLink": {
+              "url": "https://github.com/${REPO}/pull/${PR_NUMBER}"
+            }
+          }
+        },
+        {
+          "text": "View Workflow Run",
+          "onClick": {
+            "openLink": {
+              "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
+            }
+          }
+        }
+      ]
+    }
+  }
+EOF
+  )
+fi
+
+# Get the logo URL - using color logo with no background
+LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/217183861/Logo%20Files/png/Color%20logo%20-%20no%20background.png"
+
+# Create Google Chat card format JSON for validation results
+if [ -z "$PR_NUMBER" ]; then
+  # For branch push validations
+  JSON_PAYLOAD=$(cat <<EOF
+{
+  "cardsV2": [{
+    "card": {
+      "header": {
+        "title": "📋 Documentation Validation",
+        "subtitle": "${REPO}",
+        "imageStyle": "AVATAR",
+        "imageUrl": "${LOGO_URL}"
+      },
+      "sections": [
+        {
+          "header": "✅ Validation Successful",
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "Documentation validation has successfully completed for branch push."
+              }
+            },
+            {
+              "buttonList": {
+                "buttons": [
+                  {
+                    "text": "View Workflow Run",
+                    "onClick": {
+                      "openLink": {
+                        "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }]
+}
+EOF
+)
+else
+  # For PR validations
+  JSON_PAYLOAD=$(cat <<EOF
+{
+  "cardsV2": [{
+    "card": {
+      "header": {
+        "title": "📋 Documentation Validation",
+        "subtitle": "${REPO}",
+        "imageStyle": "AVATAR",
+        "imageUrl": "${LOGO_URL}"
+      },
+      "sections": [
+        {
+          "header": "✅ Validation Successful",
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "Documentation validation has successfully completed for PR #${PR_NUMBER}."
+              }
+            },
+            {
+              "keyValue": {
+                "topLabel": "Pull Request",
+                "content": "${PR_INFO}"
+              }
+            },
+            {
+              "keyValue": {
+                "topLabel": "Author",
+                "content": "${PR_AUTHOR_INFO}"
+              }
+            },
+            ${PR_BUTTONS}
+          ]
+        }
+      ]
+    }
+  }]
+}
+EOF
+)
+fi
+
+# Send the notification to Google Chat
+curl -s -X POST -H "Content-Type: application/json" \
+  -d "$JSON_PAYLOAD" \
+  "$WEBHOOK_URL"
+
+echo "✅ Validation notification sent successfully"

--- a/scripts/send-validation-notification.sh
+++ b/scripts/send-validation-notification.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Script to send rich notifications about documentation deployments to Google Chat
-# Usage: ./scripts/send-notification.sh <webhook_url> <repo> <run_id>
+# Script to send focused notifications about documentation validation to Google Chat
+# Usage: ./scripts/send-validation-notification.sh <webhook_url> <repo> <run_id> <pr_number> <pr_title> <pr_author>
 
 # Exit on any error
 set -e
@@ -9,6 +9,9 @@ set -e
 WEBHOOK_URL="$1"
 REPO="$2"
 RUN_ID="$3"
+PR_NUMBER="$4"
+PR_TITLE="$5"
+PR_AUTHOR="$6"
 
 if [ -z "$WEBHOOK_URL" ]; then
   echo "❌ Error: Webhook URL is required"
@@ -25,89 +28,42 @@ if [ -z "$RUN_ID" ]; then
   exit 1
 fi
 
-# Extract organization and repository name
-IFS='/' read -r ORG REPO_NAME <<< "$REPO"
-
-# Setup URLs
-ACTIONS_URL="https://github.com/${REPO}/actions"
-GH_PAGES_URL="https://${ORG}.github.io/${REPO_NAME}/"
-CURRENT_RUN_URL="${ACTIONS_URL}/runs/${RUN_ID}"
-PAGES_WORKFLOW_URL="${ACTIONS_URL}/workflows/pages/pages-build-deployment"
-
 # Get the logo URL - using color logo with no background
 LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/217183861/Logo%20Files/png/Color%20logo%20-%20no%20background.png"
 
-# Create Google Chat card format JSON
-JSON_PAYLOAD=$(cat <<EOF
+# Create Google Chat card format JSON for validation results
+if [ -z "$PR_NUMBER" ]; then
+  # For branch push validations
+  JSON_PAYLOAD=$(cat <<EOF
 {
   "cards": [
     {
       "header": {
-        "title": "🚀 Documentation Deployment Process",
+        "title": "📋 Documentation Validation",
         "subtitle": "${REPO}",
         "imageUrl": "${LOGO_URL}"
       },
       "sections": [
         {
-          "header": "Step 1: Documentation Build & Push ✅",
           "widgets": [
             {
               "textParagraph": {
-                "text": "The documentation has been built and pushed to the gh-pages branch."
+                "text": "✅ <b>Build Successful</b>: Documentation compilation and validation has passed on branch push."
               }
             },
             {
               "buttons": [
                 {
                   "textButton": {
-                    "text": "View Build Details",
+                    "text": "View Workflow Run",
                     "onClick": {
                       "openLink": {
-                        "url": "${CURRENT_RUN_URL}"
+                        "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
                       }
                     }
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "header": "Step 2: GitHub Pages Deployment ⏳",
-          "widgets": [
-            {
-              "textParagraph": {
-                "text": "The GitHub Pages workflow has been triggered and will deploy shortly."
-              }
-            },
-            {
-              "buttons": [
-                {
-                  "textButton": {
-                    "text": "Check Pages Workflow",
-                    "onClick": {
-                      "openLink": {
-                        "url": "${PAGES_WORKFLOW_URL}"
-                      }
-                    }
-                  }
-                },
-                {
-                  "textButton": {
-                    "text": "View Documentation",
-                    "onClick": {
-                      "openLink": {
-                        "url": "${GH_PAGES_URL}"
-                      }
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "textParagraph": {
-                "text": "⚠️ Please verify the GitHub Pages deployment completed successfully"
-              }
             }
           ]
         }
@@ -117,10 +73,77 @@ JSON_PAYLOAD=$(cat <<EOF
 }
 EOF
 )
+else
+  # For PR validations
+  JSON_PAYLOAD=$(cat <<EOF
+{
+  "cards": [
+    {
+      "header": {
+        "title": "📋 Documentation Validation",
+        "subtitle": "${REPO}",
+        "imageUrl": "${LOGO_URL}"
+      },
+      "sections": [
+        {
+          "widgets": [
+            {
+              "textParagraph": {
+                "text": "✅ <b>PR Ready for Review</b>: Documentation validation has passed all checks."
+              }
+            },
+            {
+              "textParagraph": {
+                "text": "<b>Pull Request:</b> #${PR_NUMBER}: ${PR_TITLE}"
+              }
+            },
+            {
+              "textParagraph": {
+                "text": "<b>Author:</b> ${PR_AUTHOR}"
+              }
+            },
+            {
+              "textParagraph": {
+                "text": "<b>Checks Passed:</b> MkDocs build, internal links, image references"
+              }
+            },
+            {
+              "buttons": [
+                {
+                  "textButton": {
+                    "text": "Review PR",
+                    "onClick": {
+                      "openLink": {
+                        "url": "https://github.com/${REPO}/pull/${PR_NUMBER}"
+                      }
+                    }
+                  }
+                },
+                {
+                  "textButton": {
+                    "text": "View Workflow",
+                    "onClick": {
+                      "openLink": {
+                        "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+)
+fi
 
 # Send the notification to Google Chat
 curl -s -X POST -H "Content-Type: application/json" \
   -d "$JSON_PAYLOAD" \
   "$WEBHOOK_URL"
 
-echo "✅ Notification sent successfully"
+echo "✅ Validation notification sent successfully"

--- a/scripts/send-validation-notification.sh
+++ b/scripts/send-validation-notification.sh
@@ -31,36 +31,44 @@ fi
 # For non-PR runs, we may not have PR information
 if [ -z "$PR_NUMBER" ]; then
   PR_INFO="Branch push validation"
-  PR_BUTTONS=""
+  BUTTONS_SECTION="\"buttons\": [
+      {
+        \"textButton\": {
+          \"text\": \"View Workflow Run\",
+          \"onClick\": {
+            \"openLink\": {
+              \"url\": \"https://github.com/${REPO}/actions/runs/${RUN_ID}\"
+            }
+          }
+        }
+      }
+    ]"
 else
   PR_INFO="#${PR_NUMBER}: ${PR_TITLE}"
   PR_AUTHOR_INFO="${PR_AUTHOR}"
   
-  PR_BUTTONS=$(cat <<EOF
-  {
-    "buttonList": {
-      "buttons": [
-        {
-          "text": "View Pull Request",
-          "onClick": {
-            "openLink": {
-              "url": "https://github.com/${REPO}/pull/${PR_NUMBER}"
-            }
-          }
-        },
-        {
-          "text": "View Workflow Run",
-          "onClick": {
-            "openLink": {
-              "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
+  BUTTONS_SECTION="\"buttons\": [
+      {
+        \"textButton\": {
+          \"text\": \"View Pull Request\",
+          \"onClick\": {
+            \"openLink\": {
+              \"url\": \"https://github.com/${REPO}/pull/${PR_NUMBER}\"
             }
           }
         }
-      ]
-    }
-  }
-EOF
-  )
+      },
+      {
+        \"textButton\": {
+          \"text\": \"View Workflow Run\",
+          \"onClick\": {
+            \"openLink\": {
+              \"url\": \"https://github.com/${REPO}/actions/runs/${RUN_ID}\"
+            }
+          }
+        }
+      }
+    ]"
 fi
 
 # Get the logo URL - using color logo with no background
@@ -71,12 +79,11 @@ if [ -z "$PR_NUMBER" ]; then
   # For branch push validations
   JSON_PAYLOAD=$(cat <<EOF
 {
-  "cardsV2": [{
-    "card": {
+  "cards": [
+    {
       "header": {
         "title": "📋 Documentation Validation",
         "subtitle": "${REPO}",
-        "imageStyle": "AVATAR",
         "imageUrl": "${LOGO_URL}"
       },
       "sections": [
@@ -87,26 +94,15 @@ if [ -z "$PR_NUMBER" ]; then
               "textParagraph": {
                 "text": "Documentation validation has successfully completed for branch push."
               }
-            },
-            {
-              "buttonList": {
-                "buttons": [
-                  {
-                    "text": "View Workflow Run",
-                    "onClick": {
-                      "openLink": {
-                        "url": "https://github.com/${REPO}/actions/runs/${RUN_ID}"
-                      }
-                    }
-                  }
-                ]
-              }
             }
           ]
+        },
+        {
+          ${BUTTONS_SECTION}
         }
       ]
     }
-  }]
+  ]
 }
 EOF
 )
@@ -114,12 +110,11 @@ else
   # For PR validations
   JSON_PAYLOAD=$(cat <<EOF
 {
-  "cardsV2": [{
-    "card": {
+  "cards": [
+    {
       "header": {
         "title": "📋 Documentation Validation",
         "subtitle": "${REPO}",
-        "imageStyle": "AVATAR",
         "imageUrl": "${LOGO_URL}"
       },
       "sections": [
@@ -132,23 +127,23 @@ else
               }
             },
             {
-              "keyValue": {
-                "topLabel": "Pull Request",
-                "content": "${PR_INFO}"
+              "textParagraph": {
+                "text": "<b>Pull Request:</b> ${PR_INFO}"
               }
             },
             {
-              "keyValue": {
-                "topLabel": "Author",
-                "content": "${PR_AUTHOR_INFO}"
+              "textParagraph": {
+                "text": "<b>Author:</b> ${PR_AUTHOR_INFO}"
               }
-            },
-            ${PR_BUTTONS}
+            }
           ]
+        },
+        {
+          ${BUTTONS_SECTION}
         }
       ]
     }
-  }]
+  ]
 }
 EOF
 )

--- a/scripts/send-validation-notification.sh
+++ b/scripts/send-validation-notification.sh
@@ -31,6 +31,15 @@ fi
 # Get the logo URL - using color logo with no background
 LOGO_URL="https://raw.githubusercontent.com/${REPO}/main/docs/assets/images/217183861/Logo%20Files/png/Color%20logo%20-%20no%20background.png"
 
+# Create a unique thread key based on the branch or PR
+if [ -z "$PR_NUMBER" ]; then
+  # For branch push validations
+  THREAD_KEY="${REPO}-branch-$(echo $GITHUB_REF | cut -d/ -f3-)"
+else
+  # For PR validations
+  THREAD_KEY="${REPO}-pr-${PR_NUMBER}"
+fi
+
 # Create Google Chat card format JSON for validation results
 if [ -z "$PR_NUMBER" ]; then
   # For branch push validations
@@ -69,7 +78,10 @@ if [ -z "$PR_NUMBER" ]; then
         }
       ]
     }
-  ]
+  ],
+  "thread": {
+    "threadKey": "${THREAD_KEY}"
+  }
 }
 EOF
 )
@@ -135,7 +147,10 @@ else
         }
       ]
     }
-  ]
+  ],
+  "thread": {
+    "threadKey": "${THREAD_KEY}"
+  }
 }
 EOF
 )


### PR DESCRIPTION
This MR adds improved notification capabilities for our documentation workflows:

- Creates two notification scripts in the scripts/ directory:
  1. send-notification.sh - For deployment notifications
  2. send-validation-notification.sh - For validation notifications
  
- Updates GitHub Actions workflows to use these scripts
- Implements rich Google Chat card-based notifications with:
  - Visual status indicators
  - Clickable links to relevant workflows and PRs
  - Company logo
  - Clear separation between deployment and validation notifications

These changes make our CI/CD notifications more informative and actionable.